### PR TITLE
Add support for fullscreen option

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -49,6 +49,10 @@ function alwaysOnTop(argv) {
     return argv.indexOf('--always-on-top') >= 0;
 }
 
+function shouldFullScreen(argv) {
+    return argv.indexOf('--fullscreen') >= 0;
+}
+
 const shouldQuit = app.makeSingleInstance((argv, workdir) => {
     if (win !== null) {
         if (win.isMinimized(0)) {
@@ -101,6 +105,10 @@ app.once('ready', () => {
             win.show();
         } else {
             win.showInactive();
+        }
+
+        if (shouldFullScreen(process.argv)) {
+            win.setFullScreen(true);
         }
     });
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -39,6 +39,11 @@ function parseArgv(argv) {
         argv.splice(always_on_top_idx, 1);
     }
 
+    const fullscreen_idx = argv.indexOf('--fullscreen');
+    if (fullscreen_idx >= 0) {
+        argv.splice(fullscreen_idx, 1);
+    }
+
     const width = parseIntArg('width', argv);
     const height = parseIntArg('height', argv);
 
@@ -53,6 +58,7 @@ function parseArgv(argv) {
         fallback: fallback_idx >= 0,
         focus: without_focus_idx < 0,
         alwaysOnTop: always_on_top_idx >= 0,
+        fullscreen: fullscreen_idx >= 0,
         width,
         height,
     };
@@ -85,6 +91,9 @@ Options:
 
     --always-on-top
         Show a window always on top of desktop.
+
+    --fullscreen
+        Show a window in fullscreen mode.
 
     --help
         Show this help.

--- a/index.js
+++ b/index.js
@@ -43,6 +43,9 @@ function open(parsed) {
     if (parsed.alwaysOnTop) {
         args.push('--always-on-top');
     }
+    if (parsed.fullscreen) {
+        args.push('--fullscreen');
+    }
 
     child_process.spawn(electron, args, {
         stdio: 'ignore',


### PR DESCRIPTION
If someone want to open the application in fullscreen without
menu-bar (windows/linux). This will put the application in fullscreen
mode.

Another option could also be to only hide the menu without setting
fullscreen. But this works for me.

That would use something like:

```
win.setMenu(null);
```

Fix for #1 