### PR TITLE
Add support for	disable-menu option

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -53,6 +53,10 @@ function shouldFullScreen(argv) {
     return argv.indexOf('--fullscreen') >= 0;
 }
 
+function disableMenu(argv) {
+    return argv.indexOf('--disable-menu') >= 0;
+}
+
 const shouldQuit = app.makeSingleInstance((argv, workdir) => {
     if (win !== null) {
         if (win.isMinimized(0)) {
@@ -109,6 +113,10 @@ app.once('ready', () => {
 
         if (shouldFullScreen(process.argv)) {
             win.setFullScreen(true);
+        }
+
+        if (disableMenu(process.argv)) {
+            win.setMenu(null);
         }
     });
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -44,6 +44,11 @@ function parseArgv(argv) {
         argv.splice(fullscreen_idx, 1);
     }
 
+    const disable_menu_idx = argv.indexOf('--disable-menu');
+    if (disable_menu_idx >= 0) {
+        argv.splice(disable_menu_idx, 1);
+    }
+
     const width = parseIntArg('width', argv);
     const height = parseIntArg('height', argv);
 
@@ -59,6 +64,7 @@ function parseArgv(argv) {
         focus: without_focus_idx < 0,
         alwaysOnTop: always_on_top_idx >= 0,
         fullscreen: fullscreen_idx >= 0,
+        disableMenu: disable_menu_idx >= 0,
         width,
         height,
     };
@@ -94,6 +100,9 @@ Options:
 
     --fullscreen
         Show a window in fullscreen mode.
+
+    --disable-menu
+        Disable the window menu.
 
     --help
         Show this help.

--- a/index.js
+++ b/index.js
@@ -46,6 +46,9 @@ function open(parsed) {
     if (parsed.fullscreen) {
         args.push('--fullscreen');
     }
+    if (parsed.disableMenu) {
+        args.push('--disable-menu');
+    }
 
     child_process.spawn(electron, args, {
         stdio: 'ignore',


### PR DESCRIPTION
This option disables the menu for systems that show the menu. The caveat
here is that it seems the operations that can be used through the menu
doesn't work anymore. Like zooming in/out and presumably toggling full
screen etc.

I also got the idea now, that it might be nice to be able to control the
initial zoom level etc.